### PR TITLE
Disable map scroll wheel zoom

### DIFF
--- a/app.py
+++ b/app.py
@@ -158,9 +158,9 @@ with right:
     tile_url = tile_options[tile_choice]
 
     if tile_url.startswith("http"):
-        m = folium.Map(location=center, zoom_start=15, tiles=tile_url, attr=tile_choice)
+        m = folium.Map(location=center, zoom_start=15, tiles=tile_url, attr=tile_choice, scrollWheelZoom=False)
     else:
-        m = folium.Map(location=center, zoom_start=15, tiles=tile_url)
+        m = folium.Map(location=center, zoom_start=15, tiles=tile_url, scrollWheelZoom=False)
 
     Fullscreen(position="topleft", title="Pantalla completa", title_cancel="Salir").add_to(m)
 


### PR DESCRIPTION
## Summary
- Disable scroll wheel zoom on folium map to avoid unwanted scrolling and stray code appearing on screen

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689bbfccc558832dbe89af76e985e7e1